### PR TITLE
Add age-encrypted state handling

### DIFF
--- a/cmd/keptler/generate.go
+++ b/cmd/keptler/generate.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"path/filepath"
+
+	"keptler/internal/generate"
+	"keptler/internal/parser"
+)
+
+func runGenerate(args []string, quiet, jsonOut, noColor bool) error {
+	fs := flag.NewFlagSet("generate", flag.ContinueOnError)
+	template := fs.String("f", "env.example", "Template file")
+	outPath := fs.String("o", "secret.env", "Output file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	tmpl, err := parser.ParseEnvExample(*template)
+	if err != nil {
+		return fmt.Errorf("parse template: %w", err)
+	}
+
+	statePath := filepath.Join(filepath.Dir(*outPath), ".keptler.state.age")
+	values, err := generate.Materialise(tmpl, *outPath, statePath)
+	if err != nil {
+		return err
+	}
+
+	if !quiet {
+		for k := range values {
+			fmt.Println("generated", k)
+		}
+	}
+
+	return nil
+}

--- a/cmd/keptler/main.go
+++ b/cmd/keptler/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	quiet := flag.Bool("quiet", false, "Suppress non-error output")
+	jsonOut := flag.Bool("json", false, "Machine-readable output")
+	noColor := flag.Bool("no-color", false, "Disable ANSI colours")
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "expected command")
+		os.Exit(1)
+	}
+
+	cmd := flag.Arg(0)
+	args := flag.Args()[1:]
+
+	switch cmd {
+	case "generate":
+		if err := runGenerate(args, *quiet, *jsonOut, *noColor); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintln(os.Stderr, "unknown command:", cmd)
+		os.Exit(1)
+	}
+}

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,0 +1,23 @@
+# Development Tasks
+
+This document tracks the current implementation tasks for the Keptler CLI prototype.
+
+## Initial Goals
+
+- [x] CLI skeleton with global flags
+- [x] `generate` command (local only)
+- [x] Parse `.env.example` annotations
+- [x] Generate random strings
+- [x] Generate RSA private keys
+- [x] Write output `secret.env`
+- [x] Store/reuse values from `.keptler.state.age`
+- [x] Unit tests for parser and generator
+
+## Backlog
+
+- [x] Age-encrypt state file
+- [ ] Support remote GitHub secrets
+- [ ] `list` command
+- [ ] `rotate` command
+- [ ] `validate` command
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module keptler
+
+go 1.23.8
+
+require filippo.io/age v1.2.1
+
+require (
+	golang.org/x/crypto v0.24.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
+filippo.io/age v1.2.1 h1:X0TZjehAZylOIj4DubWYU1vWQxv9bJpo+Uu2/LGhi1o=
+filippo.io/age v1.2.1/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
+golang.org/x/crypto v0.24.0 h1:mnl8DM0o513X8fdIkmyFE/5hTYxbwYOjDS/+rK6qpRI=
+golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5DM=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -1,0 +1,255 @@
+package generate
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"filippo.io/age"
+	"filippo.io/age/armor"
+
+	"keptler/internal/parser"
+)
+
+type stateFile struct {
+	Values map[string]string `json:"values"`
+}
+
+// Materialise ensures all secrets exist and writes them to outPath and statePath.
+func Materialise(tmpl *parser.Template, outPath, statePath string) (map[string]string, error) {
+	state := loadState(statePath)
+	outVals := loadEnv(outPath)
+
+	changed := false
+	for _, s := range tmpl.Secrets {
+		if v, ok := outVals[s.Name]; ok {
+			state.Values[s.Name] = v
+			continue
+		}
+		if v, ok := state.Values[s.Name]; ok {
+			outVals[s.Name] = v
+			continue
+		}
+		v, err := generateValue(s)
+		if err != nil {
+			return nil, fmt.Errorf("generate %s: %w", s.Name, err)
+		}
+		state.Values[s.Name] = v
+		outVals[s.Name] = v
+		changed = true
+	}
+
+	if changed {
+		if err := writeEnv(outPath, outVals); err != nil {
+			return nil, err
+		}
+		if err := saveState(statePath, state); err != nil {
+			return nil, err
+		}
+	}
+
+	return outVals, nil
+}
+
+func generateValue(s parser.SecretTemplate) (string, error) {
+	switch s.Rule {
+	case "random":
+		length := atoiDefault(s.Params["length"], 32)
+		charset := s.Params["charset"]
+		if charset == "" {
+			charset = "alnum"
+		}
+		return randomString(length, charset)
+	case "rsa-private-key":
+		bits := atoiDefault(s.Params["bits"], 2048)
+		format := s.Params["format"]
+		if format == "" {
+			format = "pkcs1"
+		}
+		return generateRSA(bits, format)
+	case "derive":
+		src := s.Params["source"]
+		if src == "" {
+			return "", errors.New("derive requires source")
+		}
+		return "${" + src + "}", nil
+	default:
+		return "", fmt.Errorf("unsupported rule %q", s.Rule)
+	}
+}
+
+func randomString(length int, charset string) (string, error) {
+	switch charset {
+	case "alnum":
+		const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+		return randChars(length, letters)
+	case "hex":
+		b := make([]byte, length)
+		if _, err := rand.Read(b); err != nil {
+			return "", err
+		}
+		return hex.EncodeToString(b)[:length], nil
+	case "base64":
+		b := make([]byte, length)
+		if _, err := rand.Read(b); err != nil {
+			return "", err
+		}
+		return base64.StdEncoding.EncodeToString(b)[:length], nil
+	case "urlsafe":
+		b := make([]byte, length)
+		if _, err := rand.Read(b); err != nil {
+			return "", err
+		}
+		return base64.RawURLEncoding.EncodeToString(b)[:length], nil
+	default:
+		return "", fmt.Errorf("unknown charset %q", charset)
+	}
+}
+
+func randChars(length int, letters string) (string, error) {
+	var sb strings.Builder
+	max := big.NewInt(int64(len(letters)))
+	for i := 0; i < length; i++ {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteByte(letters[n.Int64()])
+	}
+	return sb.String(), nil
+}
+
+func generateRSA(bits int, format string) (string, error) {
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return "", err
+	}
+	if format == "pkcs8" {
+		b, err := x509.MarshalPKCS8PrivateKey(key)
+		if err != nil {
+			return "", err
+		}
+		return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: b})), nil
+	}
+	b := x509.MarshalPKCS1PrivateKey(key)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: b})), nil
+}
+
+func atoiDefault(s string, def int) int {
+	if v, err := strconv.Atoi(s); err == nil {
+		return v
+	}
+	return def
+}
+
+func statePassphrase() string {
+	if p := os.Getenv("KEPTLER_STATE_PASSPHRASE"); p != "" {
+		return p
+	}
+	return "localdev"
+}
+
+func loadState(path string) stateFile {
+	var s stateFile
+	s.Values = make(map[string]string)
+	f, err := os.Open(path)
+	if err != nil {
+		return s
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err == nil && fi.Mode().Perm()&0o077 != 0 {
+		return s
+	}
+	ar := armor.NewReader(f)
+	id, err := age.NewScryptIdentity(statePassphrase())
+	if err != nil {
+		return s
+	}
+	r, err := age.Decrypt(ar, id)
+	if err != nil {
+		return s
+	}
+	json.NewDecoder(r).Decode(&s)
+	return s
+}
+
+func saveState(path string, s stateFile) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	recipient, err := age.NewScryptRecipient(statePassphrase())
+	if err != nil {
+		return err
+	}
+	aw := armor.NewWriter(f)
+	w, err := age.Encrypt(aw, recipient)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(&s); err != nil {
+		w.Close()
+		aw.Close()
+		return err
+	}
+	if err := w.Close(); err != nil {
+		aw.Close()
+		return err
+	}
+	return aw.Close()
+}
+
+func loadEnv(path string) map[string]string {
+	m := make(map[string]string)
+	f, err := os.Open(path)
+	if err != nil {
+		return m
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if idx := strings.Index(line, "="); idx != -1 {
+			k := strings.TrimSpace(line[:idx])
+			v := strings.TrimSpace(line[idx+1:])
+			m[k] = v
+		}
+	}
+	return m
+}
+
+func writeEnv(path string, values map[string]string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if _, err := io.WriteString(f, fmt.Sprintf("%s=%s\n", k, values[k])); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1,0 +1,28 @@
+package generate
+
+import (
+	"os"
+	"testing"
+
+	"keptler/internal/parser"
+)
+
+func TestMaterialiseRandom(t *testing.T) {
+	tmpl := &parser.Template{Secrets: []parser.SecretTemplate{
+		{Name: "A", Rule: "random", Params: map[string]string{"length": "8", "charset": "alnum"}},
+	}}
+	out, err := os.CreateTemp("", "out-env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Remove(out.Name())
+	state := out.Name() + ".state.age"
+
+	values, err := Materialise(tmpl, out.Name(), state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := values["A"]; !ok || len(v) != 8 {
+		t.Fatalf("unexpected value: %v", values)
+	}
+}

--- a/internal/parser/env.go
+++ b/internal/parser/env.go
@@ -1,0 +1,85 @@
+package parser
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SecretTemplate represents a single secret specification parsed from .env.example
+// comments.
+type SecretTemplate struct {
+	Name   string
+	Rule   string
+	Params map[string]string
+}
+
+// Template holds all parsed secret templates.
+type Template struct {
+	Secrets []SecretTemplate
+}
+
+// ParseEnvExample reads the given file and extracts keptler annotations.
+func ParseEnvExample(path string) (*Template, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var tmpl Template
+	scanner := bufio.NewScanner(f)
+	var pending map[string]string
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# keptler:") {
+			params, err := parseAnnotation(strings.TrimPrefix(trimmed, "# keptler:"))
+			if err != nil {
+				return nil, err
+			}
+			pending = params
+			continue
+		}
+
+		if idx := strings.Index(line, "="); idx != -1 {
+			name := strings.TrimSpace(line[:idx])
+			rest := line[idx+1:]
+			ann := pending
+			pending = nil
+			if i := strings.Index(rest, "# keptler:"); i != -1 {
+				params, err := parseAnnotation(rest[i+len("# keptler:"):])
+				if err != nil {
+					return nil, err
+				}
+				ann = params
+			}
+			if ann != nil {
+				tmpl.Secrets = append(tmpl.Secrets, SecretTemplate{Name: name, Rule: ann["rule"], Params: ann})
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return &tmpl, nil
+}
+
+func parseAnnotation(text string) (map[string]string, error) {
+	parts := strings.Fields(strings.TrimSpace(text))
+	if len(parts) == 0 {
+		return nil, errors.New("empty annotation")
+	}
+	params := make(map[string]string)
+	params["rule"] = parts[0]
+	for _, p := range parts[1:] {
+		kv := strings.SplitN(p, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid param %q", p)
+		}
+		params[kv[0]] = kv[1]
+	}
+	return params, nil
+}

--- a/internal/parser/env_test.go
+++ b/internal/parser/env_test.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseEnvExample(t *testing.T) {
+	content := `# keptler: random length=10 charset=hex
+SECRET_ONE=
+SECRET_TWO= # keptler: rsa-private-key bits=1024
+`
+	f, err := os.CreateTemp("", "env-example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	tmpl, err := ParseEnvExample(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tmpl.Secrets) != 2 {
+		t.Fatalf("expected 2 secrets, got %d", len(tmpl.Secrets))
+	}
+	if tmpl.Secrets[0].Name != "SECRET_ONE" || tmpl.Secrets[0].Rule != "random" {
+		t.Fatalf("unexpected first secret: %+v", tmpl.Secrets[0])
+	}
+	if tmpl.Secrets[1].Rule != "rsa-private-key" {
+		t.Fatalf("unexpected second secret rule: %s", tmpl.Secrets[1].Rule)
+	}
+}


### PR DESCRIPTION
## Summary
- move TASKS into docs folder and mark completed items
- encrypt `.keptler.state.age` using age passphrase
- write output files with strict permissions and sorted keys
- use new state path in CLI

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fd546afac83208740d87814fdd245