### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Install dependencies
+        run: go mod download
+      - name: Run tests
+        run: go test ./...
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+project_name: keptler
+builds:
+  - main: ./cmd/keptler
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags: -s -w
+archives:
+  - id: keptler
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+    replacements:
+      darwin: macOS
+release:
+  github:
+    owner: ${{ github.repository_owner }}
+    name: keptler
+    draft: true
+    prerelease: false
+

--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ The `generate` command materialises secrets declared in your template:
 `secret.env` and the Age-encrypted `.keptler.state.age` file are created in the working directory. Subsequent runs reuse existing values when possible.
 
 See [docs/Functional Specification.md](docs/Functional%20Specification.md) for the detailed specification and [docs/TASKS.md](docs/TASKS.md) for the development roadmap.
+
+## Automated Releases
+
+Tagged commits are built and published by GitHub Actions using
+[GoReleaser](https://goreleaser.com/). The workflow cross‑compiles
+`keptler` for Linux, macOS and Windows on both `amd64` and `arm64`
+architectures and uploads the archives to the corresponding GitHub Release.


### PR DESCRIPTION
## Summary
- build multiplatform binaries on tag push using GoReleaser
- add GoReleaser config
- describe automated releases in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6850103ece8c8320b49d88b7ad1ee2f9