### PR TITLE
Fix GoReleaser config for v1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,12 +15,10 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
-    replacements:
-      darwin: macOS
 release:
+  draft: true
+  prerelease: false
   github:
-    owner: ${{ github.repository_owner }}
+    owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
     name: keptler
-    draft: true
-    prerelease: false
 


### PR DESCRIPTION
## Summary
- fix goreleaser config to use v1 field names
- validate config with goreleaser check

## Testing
- `go test ./...`
- `goreleaser check`

------
https://chatgpt.com/codex/tasks/task_e_68501d9e12888320b813ab1737e9069f