### PR TITLE
Fix GitHub release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary
- grant `contents: write` in release workflow

## Testing
- `go test ./...`
- `go vet ./...`
- `goreleaser check`


------
https://chatgpt.com/codex/tasks/task_e_68502285325c8320b24444390ee1935d