### PR TITLE
Add binary install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,21 @@ Keptler is a generation-first secrets CLI. It turns annotated `.env.example` tem
 
 ## Installation
 
-This project requires Go 1.23 or newer. To build the `keptler` binary, run:
+### Using the install script
+
+The repository ships pre‑built binaries for Linux and macOS. Install the
+latest release by running:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/keptler/keptler/main/install.sh | sh
+```
+
+The script downloads the archive for your platform and places the `keptler`
+binary in `/usr/local/bin` (falling back to `~/.local/bin` when necessary).
+
+### Building from source
+
+This project requires Go 1.23 or newer. To build the binary yourself, run:
 
 ```bash
 go build ./cmd/keptler

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="keptler/keptler"
+OS="$(uname -s)"
+case "$OS" in
+    Linux) OS=linux ;;
+    Darwin) OS=darwin ;;
+    *) echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64|amd64) ARCH=amd64 ;;
+    arm64|aarch64) ARCH=arm64 ;;
+    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | \
+  grep tag_name | head -n1 | cut -d '"' -f4)
+TARBALL="keptler_${LATEST}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/$REPO/releases/download/${LATEST}/${TARBALL}"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+curl -fsSL "$URL" -o "$tmpdir/$TARBALL"
+tar -xzf "$tmpdir/$TARBALL" -C "$tmpdir"
+
+DEST="/usr/local/bin"
+if install -m 0755 "$tmpdir/keptler" "$DEST/keptler" 2>/dev/null; then
+    echo "Installed keptler to $DEST/keptler"
+else
+    DEST="$HOME/.local/bin"
+    mkdir -p "$DEST"
+    install -m 0755 "$tmpdir/keptler" "$DEST/keptler"
+    echo "Installed keptler to $DEST/keptler"
+fi


### PR DESCRIPTION
## Summary
- add an install.sh script to fetch the latest release binary
- document the script in README with instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685025453de08320bf459fbf564ca019