### PR TITLE
Fix install script asset URLs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,9 @@ esac
 
 LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | \
   grep tag_name | head -n1 | cut -d '"' -f4)
-TARBALL="keptler_${LATEST}_${OS}_${ARCH}.tar.gz"
+# Release assets are named without the leading 'v' prefix used in tag names.
+VERSION="${LATEST#v}"
+TARBALL="keptler_${VERSION}_${OS}_${ARCH}.tar.gz"
 URL="https://github.com/$REPO/releases/download/${LATEST}/${TARBALL}"
 
 tmpdir=$(mktemp -d)


### PR DESCRIPTION
## Summary
- fix version handling in `install.sh`

## Testing
- `go test ./...`
- `bash install.sh`
- `/usr/local/bin/keptler --help`

------
https://chatgpt.com/codex/tasks/task_e_68502b7542148320a67b68563ed16c18