### PR TITLE
Fix install path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The repository ships pre‑built binaries for Linux and macOS. Install the
 latest release by running:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/iedmrc/keptler/main/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/iedmrc/keptler/main/install.sh | sudo sh
 ```
 
 The script downloads the archive for your platform and places the `keptler`

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ The repository ships pre‑built binaries for Linux and macOS. Install the
 latest release by running:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/iedmrc/keptler/refs/heads/main/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/iedmrc/keptler/main/install.sh | sh
 ```
 
 The script downloads the archive for your platform and places the `keptler`
 binary in `/usr/local/bin` (falling back to `~/.local/bin` when necessary).
+If `/usr/local/bin` isn't writable, run the script with `sudo` or add
+`$HOME/.local/bin` to your `PATH` so the fallback location is recognised.
 
 ### Building from source
 

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,9 @@ esac
 
 LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | \
   grep tag_name | head -n1 | cut -d '"' -f4)
-TARBALL="keptler_${LATEST}_${OS}_${ARCH}.tar.gz"
+# Release assets are named without the leading 'v' prefix used in tag names.
+VERSION="${LATEST#v}"
+TARBALL="keptler_${VERSION}_${OS}_${ARCH}.tar.gz"
 URL="https://github.com/$REPO/releases/download/${LATEST}/${TARBALL}"
 
 tmpdir=$(mktemp -d)


### PR DESCRIPTION
## Summary
- clarify install path fallback in README
- document URL fix in `install.sh`

## Testing
- `go test ./...`
- `bash install.sh`
- `/usr/local/bin/keptler --help`


------
https://chatgpt.com/codex/tasks/task_e_68502b7542148320a67b68563ed16c18