### PR TITLE
Improve CLI help and add uninstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ binary in `/usr/local/bin` (falling back to `~/.local/bin` when necessary).
 If `/usr/local/bin` isn't writable, run the script with `sudo` or add
 `$HOME/.local/bin` to your `PATH` so the fallback location is recognised.
 
+### Uninstallation
+
+To remove a previously installed binary, run:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/iedmrc/keptler/main/uninstall.sh | sudo sh
+```
+
+The script deletes `keptler` from `/usr/local/bin` or `~/.local/bin` if present.
+
 ### Building from source
 
 This project requires Go 1.23 or newer. To build the binary yourself, run:

--- a/cmd/keptler/generate.go
+++ b/cmd/keptler/generate.go
@@ -14,6 +14,9 @@ func runGenerate(args []string, quiet, jsonOut, noColor bool) error {
 	template := fs.String("f", "env.example", "Template file")
 	outPath := fs.String("o", "secret.env", "Output file")
 	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/keptler/main.go
+++ b/cmd/keptler/main.go
@@ -7,13 +7,14 @@ import (
 )
 
 func main() {
+	flag.Usage = usage
 	quiet := flag.Bool("quiet", false, "Suppress non-error output")
 	jsonOut := flag.Bool("json", false, "Machine-readable output")
 	noColor := flag.Bool("no-color", false, "Disable ANSI colours")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "expected command")
+		flag.Usage()
 		os.Exit(1)
 	}
 
@@ -28,6 +29,27 @@ func main() {
 		}
 	default:
 		fmt.Fprintln(os.Stderr, "unknown command:", cmd)
+		flag.Usage()
 		os.Exit(1)
 	}
+}
+
+func usage() {
+	out := flag.CommandLine.Output()
+	fmt.Fprintf(out, "Usage: %s [flags] <command>\n\n", os.Args[0])
+	fmt.Fprintln(out, "Commands:")
+	fmt.Fprintln(out, "  generate\tGenerate secrets from a template")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Global flags:")
+	prev := flag.CommandLine.Output()
+	flag.CommandLine.SetOutput(out)
+	flag.CommandLine.PrintDefaults()
+	flag.CommandLine.SetOutput(prev)
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Usage of generate:\n  %s generate [flags]\n", os.Args[0])
+	fs := flag.NewFlagSet("generate", flag.ContinueOnError)
+	fs.SetOutput(out)
+	fs.String("f", "env.example", "Template file")
+	fs.String("o", "secret.env", "Output file")
+	fs.PrintDefaults()
 }

--- a/install.sh
+++ b/install.sh
@@ -4,19 +4,25 @@ set -euo pipefail
 REPO="iedmrc/keptler"
 OS="$(uname -s)"
 case "$OS" in
-    Linux) OS=linux ;;
-    Darwin) OS=darwin ;;
-    *) echo "Unsupported OS: $OS" >&2; exit 1 ;;
+Linux) OS=linux ;;
+Darwin) OS=darwin ;;
+*)
+	echo "Unsupported OS: $OS" >&2
+	exit 1
+	;;
 esac
 ARCH="$(uname -m)"
 case "$ARCH" in
-    x86_64|amd64) ARCH=amd64 ;;
-    arm64|aarch64) ARCH=arm64 ;;
-    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+x86_64 | amd64) ARCH=amd64 ;;
+arm64 | aarch64) ARCH=arm64 ;;
+*)
+	echo "Unsupported architecture: $ARCH" >&2
+	exit 1
+	;;
 esac
 
-LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | \
-  grep tag_name | head -n1 | cut -d '"' -f4)
+LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
+	grep tag_name | head -n1 | cut -d '"' -f4)
 # Release assets are named without the leading 'v' prefix used in tag names.
 VERSION="${LATEST#v}"
 TARBALL="keptler_${VERSION}_${OS}_${ARCH}.tar.gz"
@@ -29,10 +35,10 @@ tar -xzf "$tmpdir/$TARBALL" -C "$tmpdir"
 
 DEST="/usr/local/bin"
 if install -m 0755 "$tmpdir/keptler" "$DEST/keptler" 2>/dev/null; then
-    echo "Installed keptler to $DEST/keptler"
+	echo "Installed keptler to $DEST/keptler"
 else
-    DEST="$HOME/.local/bin"
-    mkdir -p "$DEST"
-    install -m 0755 "$tmpdir/keptler" "$DEST/keptler"
-    echo "Installed keptler to $DEST/keptler"
+	DEST="$HOME/.local/bin"
+	mkdir -p "$DEST"
+	install -m 0755 "$tmpdir/keptler" "$DEST/keptler"
+	echo "Installed keptler to $DEST/keptler"
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+removed=false
+if [ -f /usr/local/bin/keptler ]; then
+	rm -f /usr/local/bin/keptler
+	echo "Removed /usr/local/bin/keptler"
+	removed=true
+fi
+if [ -f "$HOME/.local/bin/keptler" ]; then
+	rm -f "$HOME/.local/bin/keptler"
+	echo "Removed $HOME/.local/bin/keptler"
+	removed=true
+fi
+if [ "$removed" = false ]; then
+	echo "keptler binary not found in standard locations" >&2
+fi


### PR DESCRIPTION
## Summary
- enhance `--help` output with commands and usage details
- show help when no command is given
- silence error when `generate --help` is invoked
- document uninstall instructions and provide helper script

## Testing
- `go vet ./...`
- `go test ./...`
- `go run ./cmd/keptler`
- `go run ./cmd/keptler --help`
- `go run ./cmd/keptler generate --help`


------
https://chatgpt.com/codex/tasks/task_e_6850325f74e88320bb6ee9c5fecde58a